### PR TITLE
update ros key

### DIFF
--- a/docker/generic/Dockerfile.kinetic
+++ b/docker/generic/Dockerfile.kinetic
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 
 # Intall ROS
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 RUN apt-get update && apt-get install -y ros-kinetic-desktop-full ros-kinetic-nmea-msgs ros-kinetic-nmea-navsat-driver ros-kinetic-sound-play ros-kinetic-jsk-visualization ros-kinetic-grid-map ros-kinetic-gps-common
 RUN apt-get update && apt-get install -y ros-kinetic-controller-manager ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-gazebo-ros-control ros-kinetic-joystick-drivers ros-kinetic-rosbridge-server
 RUN apt-get update && apt-get install -y libnlopt-dev freeglut3-dev qtbase5-dev libqt5opengl5-dev libssh2-1-dev libarmadillo-dev libpcap-dev gksu libgl1-mesa-dev libglew-dev python-wxgtk3.0 software-properties-common libmosquitto-dev libyaml-cpp-dev python-flask python-requests


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
The keys have also changed for the ROS 2 repositories, see: Key rotation for ROS 2 apt repositories.

Compare:

- old key: 421C365BD9FF1F717815A3895523BAEEB01FA116
- new key: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654

reference:  http://answers.ros.org/question/325039/apt-update-fails-cannot-install-pkgs-key-not-working/

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
lgsvl_develop | [link](https://github.com/lgsvl/Autoware)

## Todos
- [ ] Tests

## Steps to Test or Reproduce
With old key, the docker cannot build successfully. The new key solved this issue.

```
cd Autoware/docker/generic
./build.sh kinetic
```

The docker can build successfully.